### PR TITLE
lsqlite3: fix binding a string value

### DIFF
--- a/.busted
+++ b/.busted
@@ -1,0 +1,6 @@
+return {
+	_all = {
+		lpath = "?.lua",
+		cpath = "bin/linux64/?.so;bin/osx64/?.dylib;bin/mingw64/*.dll",
+	}
+}

--- a/lsqlite3.lua
+++ b/lsqlite3.lua
@@ -1195,7 +1195,7 @@ end
 function sqlite_stmt:bind(n, value, bloblen)
 	local t = type(value)
 	if t == "string" then
-		self.db:check(sqlite3.sqlite3_bind_text(self.stmt, n, value, #value+1, sqlite3_transient))
+		self.db:check(sqlite3.sqlite3_bind_text(self.stmt, n, value, #value, sqlite3_transient))
 	elseif t == "number" then
 		self.db:check(sqlite3.sqlite3_bind_double(self.stmt, n, value))
 	elseif t == "boolean" then

--- a/lsqlite3_spec.lua
+++ b/lsqlite3_spec.lua
@@ -1,0 +1,36 @@
+local sqlite3 = require "lsqlite3"
+
+local function query(db, sql, ...)
+	local stmt = db:prepare(sql)
+	for i, value in ipairs(table.pack(...)) do
+		stmt:bind(i, value)
+	end
+
+	local rows = {}
+	for row in stmt:rows() do
+		table.insert(rows, row)
+	end
+
+	stmt:finalize()
+	return rows
+end
+
+describe("bind a string value", function()
+	test("literal and bind values should be equal", function()
+		local db = assert(sqlite3.open_memory())
+		query(db, "CREATE TABLE test (a TEXT, b TEXT)")
+		query(db, "INSERT INTO test (a, b) VALUES ('VALUE', ?1)", "VALUE")
+
+		local rows = query(db, "SELECT a, b, a==b FROM test")
+		assert.same({"VALUE", "VALUE", 1}, rows[1])
+	end)
+
+	test("backward compatibility with old records saved in a database", function()
+		local db = assert(sqlite3.open_memory())
+		query(db, "CREATE TABLE test (a TEXT, b TEXT)")
+		query(db, "INSERT INTO test (a, b) VALUES ('VALUE', ?1)", "VALUE\0")
+
+		local rows = query(db, "SELECT a, b, a==b FROM test")
+		assert.same({"VALUE", "VALUE", 0}, rows[1])
+	end)
+end)


### PR DESCRIPTION
Fixes incorrect usage of `sqlite3_bind_text` function.

Running tests:
```sh
$ busted .
```